### PR TITLE
Replace LiveData with Flow and add Koin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,8 +64,8 @@ dependencies {
     // Coroutines
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
-    implementation(libs.androidx.legacy.support.v4)
-    implementation(libs.androidx.lifecycle.extensions)
+    implementation(libs.koin.android)
+    implementation(libs.koin.compose)
 
     // Jetpack Compose
     implementation(libs.androidx.activity.compose)
@@ -73,7 +73,6 @@ dependencies {
     implementation(libs.androidx.material)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.runtime.livedata)
     debugImplementation(libs.androidx.ui.tooling)
     implementation(libs.coil.compose)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".FootballApp"
         android:allowBackup="true"
         android:icon="@mipmap/ball_icon"
         android:label="@string/app_name"

--- a/app/src/main/java/com/example/football/FootballApp.kt
+++ b/app/src/main/java/com/example/football/FootballApp.kt
@@ -1,0 +1,16 @@
+package com.example.football
+
+import android.app.Application
+import com.example.football.di.appModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+
+class FootballApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidContext(this@FootballApp)
+            modules(appModule)
+        }
+    }
+}

--- a/app/src/main/java/com/example/football/data/roomDatabase/footballDAO.kt
+++ b/app/src/main/java/com/example/football/data/roomDatabase/footballDAO.kt
@@ -1,6 +1,6 @@
 package com.example.football.data.roomDatabase
 
-import androidx.lifecycle.LiveData
+import kotlinx.coroutines.flow.Flow
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -14,10 +14,10 @@ interface footballDAO {
     into league table database
      */
     @Query("SELECT * FROM leagueTable")
-    fun getLeagueTable(): LiveData<List<LeagueTableDatabase>>
+    fun getLeagueTable(): Flow<List<LeagueTableDatabase>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAllLeagues(vararg videos: LeagueTableDatabase)
+    suspend fun insertAllLeagues(vararg videos: LeagueTableDatabase)
 
 
     /**
@@ -26,10 +26,10 @@ interface footballDAO {
     into news table database
      */
     @Query("SELECT * FROM newsTable")
-    fun getNews(): LiveData<List<NewsDatabase>>
+    fun getNews(): Flow<List<NewsDatabase>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAllNews(vararg videos: NewsDatabase)
+    suspend fun insertAllNews(vararg videos: NewsDatabase)
 
 
 }

--- a/app/src/main/java/com/example/football/di/AppModule.kt
+++ b/app/src/main/java/com/example/football/di/AppModule.kt
@@ -1,0 +1,21 @@
+package com.example.football.di
+
+import com.example.football.data.roomDatabase.FootballDatabase
+import com.example.football.repository.LeagueTableRepo
+import com.example.football.repository.NewsRepo
+import com.example.football.ui.live.LiveViewModel
+import com.example.football.ui.news.NewsViewModel
+import com.example.football.ui.table.TableViewModel
+import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val appModule = module {
+    single { FootballDatabase.getInstance(androidContext()) }
+    single { LeagueTableRepo(get()) }
+    single { NewsRepo(get()) }
+
+    viewModel { TableViewModel(get()) }
+    viewModel { NewsViewModel(get()) }
+    viewModel { LiveViewModel() }
+}

--- a/app/src/main/java/com/example/football/repository/LeagueTableRepo.kt
+++ b/app/src/main/java/com/example/football/repository/LeagueTableRepo.kt
@@ -1,8 +1,8 @@
 package com.example.football.repository
 
 import android.util.Log
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Transformations
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import com.example.football.data.network.TableApiCall
 import com.example.football.data.network.asLeagueDataBaseModel
 import com.example.football.data.roomDatabase.FootballDatabase
@@ -15,10 +15,8 @@ class LeagueTableRepo(private val leagueDatabase: FootballDatabase) {
 
 
     //
-    val getLeagueTableInDatabase: LiveData<List<LeagueTableModel>> = Transformations
-        .map(leagueDatabase.footballDAO.getLeagueTable()) {
-            it.asLeagueDomainModel()
-        }
+    val leagueTableFlow: Flow<List<LeagueTableModel>> =
+        leagueDatabase.footballDAO.getLeagueTable().map { it.asLeagueDomainModel() }
 
     //
     suspend fun refreshLeagueTable() {

--- a/app/src/main/java/com/example/football/repository/NewsRepo.kt
+++ b/app/src/main/java/com/example/football/repository/NewsRepo.kt
@@ -1,8 +1,8 @@
 package com.example.football.repository
 
 import android.util.Log
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Transformations
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import com.example.football.data.network.NewsApiCall
 import com.example.football.data.network.asNewsDataBaseModel
 import com.example.football.data.roomDatabase.FootballDatabase
@@ -15,10 +15,8 @@ class NewsRepo(private val newsdatabase: FootballDatabase) {
 
 
     //
-    val getNewsInDatabase: LiveData<List<NewsModel>> = Transformations
-        .map(newsdatabase.footballDAO.getNews()) {
-            it.asNewsDomainModel()
-        }
+    val newsFlow: Flow<List<NewsModel>> =
+        newsdatabase.footballDAO.getNews().map { it.asNewsDomainModel() }
 
 
     //

--- a/app/src/main/java/com/example/football/ui/live/LiveScore.kt
+++ b/app/src/main/java/com/example/football/ui/live/LiveScore.kt
@@ -5,23 +5,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
 import androidx.compose.ui.platform.ComposeView
 import com.example.football.ui.live.compose.LiveScoreScreen
 
 
 class LiveScore : Fragment() {
 
-    private lateinit var viewModel: LiveViewModel
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        viewModel = ViewModelProvider(this).get(LiveViewModel::class.java)
         return ComposeView(requireContext()).apply {
             setContent {
-                LiveScoreScreen(viewModel)
+                LiveScoreScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/football/ui/live/LiveViewModel.kt
+++ b/app/src/main/java/com/example/football/ui/live/LiveViewModel.kt
@@ -1,36 +1,28 @@
 package com.example.football.ui.live
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.football.data.network.LiveScoreApiCall
 import com.example.football.data.network.asLiveScoreDomainModel
 import com.example.football.domain.NetworkLiveScore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 enum class NetworkState { LOADING, SUCCESS, FAILURE }
 
 class LiveViewModel : ViewModel() {
 
-    //encapsulating liveData
-    private val _liveScore = MutableLiveData<List<NetworkLiveScore>>()
-    val liveScore: LiveData<List<NetworkLiveScore>> = _liveScore
+    private val _liveScore = MutableStateFlow<List<NetworkLiveScore>>(emptyList())
+    val liveScore: StateFlow<List<NetworkLiveScore>> = _liveScore
 
-    // The internal MutableLiveData status that stores the status of the most recent request
-    private val _status = MutableLiveData<NetworkState>()
-
-    // The external immutable LiveData for the request status String
-    val status: LiveData<NetworkState>
-        get() = _status
+    private val _status = MutableStateFlow(NetworkState.LOADING)
+    val status: StateFlow<NetworkState> = _status
 
     init {
         getLiveScores()
     }
 
-    /**
-     * send network request to get news
-     */
     fun getLiveScores() {
         viewModelScope.launch {
             try {
@@ -40,10 +32,8 @@ class LiveViewModel : ViewModel() {
                 _status.value = NetworkState.SUCCESS
             } catch (t: Throwable) {
                 _status.value = NetworkState.FAILURE
-                _liveScore.value = ArrayList()
+                _liveScore.value = emptyList()
             }
-
         }
     }
-
 }

--- a/app/src/main/java/com/example/football/ui/live/compose/LiveScoreComposable.kt
+++ b/app/src/main/java/com/example/football/ui/live/compose/LiveScoreComposable.kt
@@ -13,16 +13,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.collectAsState
+import org.koin.androidx.compose.koinViewModel
 import com.example.football.domain.NetworkLiveScore
 import com.example.football.ui.live.LiveViewModel
 import com.example.football.ui.live.NetworkState
 
 @Composable
-fun LiveScoreScreen(viewModel: LiveViewModel = viewModel()) {
-    val scores by viewModel.liveScore.observeAsState(emptyList())
-    val status by viewModel.status.observeAsState()
+fun LiveScoreScreen(viewModel: LiveViewModel = koinViewModel()) {
+    val scores by viewModel.liveScore.collectAsState()
+    val status by viewModel.status.collectAsState()
 
     when (status) {
         NetworkState.LOADING -> Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/app/src/main/java/com/example/football/ui/news/News.kt
+++ b/app/src/main/java/com/example/football/ui/news/News.kt
@@ -5,25 +5,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
 import androidx.compose.ui.platform.ComposeView
 import com.example.football.ui.news.compose.NewsScreen
 
 class News : Fragment() {
-    private lateinit var viewModel: NewsViewModel
 
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        val activity = requireNotNull(this.activity)
-        viewModel = ViewModelProvider(this, NewsViewModel.NewsFactory(activity.application))
-            .get(NewsViewModel::class.java)
-
         return ComposeView(requireContext()).apply {
             setContent {
-                NewsScreen(viewModel)
+                NewsScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/football/ui/news/NewsViewModel.kt
+++ b/app/src/main/java/com/example/football/ui/news/NewsViewModel.kt
@@ -1,50 +1,36 @@
 package com.example.football.ui.news
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.example.football.data.roomDatabase.FootballDatabase
 import com.example.football.repository.NewsRepo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-/// class the set network status
 enum class NewsNetworkState { LOADING, SUCCESS, FAILURE }
 
-class NewsViewModel(app: Application) : AndroidViewModel(app) {
+class NewsViewModel(
+    private val repo: NewsRepo
+) : ViewModel() {
 
-    //
-    private val database = FootballDatabase.getInstance(app)
-    private val repo = NewsRepo(database)
-
+    private val _status = MutableStateFlow(NewsNetworkState.SUCCESS)
+    val status: StateFlow<NewsNetworkState> = _status
 
     init {
         getRNews()
     }
 
-    /**
-     * send network request to get news
-     */
     fun getRNews() {
         viewModelScope.launch {
             repo.refreshNews()
         }
     }
 
-    val news = repo.getNewsInDatabase
-
-    /**
-     * Factory for constructing DevByteViewModel with parameter
-     */
-    class NewsFactory(private val app: Application) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(NewsViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return NewsViewModel(app) as T
-            }
-            throw IllegalArgumentException("Unable to construct viewmodel")
-        }
-    }
-
+    val news = repo.newsFlow.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = emptyList()
+    )
 }

--- a/app/src/main/java/com/example/football/ui/news/compose/NewsComposable.kt
+++ b/app/src/main/java/com/example/football/ui/news/compose/NewsComposable.kt
@@ -13,15 +13,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.collectAsState
+import org.koin.androidx.compose.koinViewModel
 import coil.compose.AsyncImage
 import com.example.football.domain.NewsModel
 import com.example.football.ui.news.NewsViewModel
 
 @Composable
-fun NewsScreen(viewModel: NewsViewModel = viewModel()) {
-    val news by viewModel.news.observeAsState(emptyList())
+fun NewsScreen(viewModel: NewsViewModel = koinViewModel()) {
+    val news by viewModel.news.collectAsState()
     if (news.isEmpty()) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = androidx.compose.ui.Alignment.Center) {
             androidx.compose.material.CircularProgressIndicator()

--- a/app/src/main/java/com/example/football/ui/table/TableFragment.kt
+++ b/app/src/main/java/com/example/football/ui/table/TableFragment.kt
@@ -6,26 +6,16 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
 import com.example.football.ui.table.compose.LeagueTableScreen
 
-
 class TableFragment : Fragment() {
-
-    private lateinit var viewModel: TableViewModel
-
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        val activity = requireNotNull(this.activity)
-        viewModel = ViewModelProvider(this, TableViewModel.TableFactory(activity.application))
-            .get(TableViewModel::class.java)
-
         return ComposeView(requireContext()).apply {
             setContent {
-                LeagueTableScreen(viewModel)
+                LeagueTableScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/football/ui/table/compose/TableComposable.kt
+++ b/app/src/main/java/com/example/football/ui/table/compose/TableComposable.kt
@@ -11,14 +11,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.collectAsState
+import org.koin.androidx.compose.koinViewModel
 import com.example.football.domain.LeagueTableModel
 import com.example.football.ui.table.TableViewModel
 
 @Composable
-fun LeagueTableScreen(viewModel: TableViewModel = viewModel()) {
-    val tables by viewModel.databaseLeagueTable.observeAsState(emptyList())
+fun LeagueTableScreen(viewModel: TableViewModel = koinViewModel()) {
+    val tables by viewModel.leagueTable.collectAsState()
 
     if (tables.isEmpty()) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ kotlin = "2.1.10"
 kotlinxCoroutinesAndroid = "1.8.1"
 kotlinxCoroutinesCore = "1.6.4"
 ksp = "2.1.10-1.0.30"
-legacySupportV4 = "1.0.0"
 lifecycleExtensions = "2.2.0"
 lifecycleViewmodelCompose = "2.9.0"
 lottie = "3.5.0"
@@ -25,8 +24,8 @@ moshiKotlin = "1.9.3"
 navigationUiKtx = "2.9.0"
 retrofit2KotlinCoroutinesAdapter = "0.9.2"
 roomKtx = "2.7.1"
-runtimeLivedata = "1.8.2"
 uiTooling = "1.8.2"
+koin = "3.5.3"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -36,8 +35,6 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
-androidx-legacy-support-v4 = { module = "androidx.legacy:legacy-support-v4", version.ref = "legacySupportV4" }
-androidx-lifecycle-extensions = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "lifecycleExtensions" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleExtensions" }
 androidx-material = { module = "androidx.compose.material:material", version.ref = "materialVersion" }
@@ -46,7 +43,6 @@ androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx",
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomKtx" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomKtx" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomKtx" }
-androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "runtimeLivedata" }
 androidx-ui = { module = "androidx.compose.ui:ui", version.ref = "uiTooling" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "uiTooling" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "uiTooling" }
@@ -66,6 +62,8 @@ moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshiKotlin" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshiKotlin" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "converterMoshi" }
 retrofit2-kotlin-coroutines-adapter = { module = "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter", version.ref = "retrofit2KotlinCoroutinesAdapter" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary
- migrate DAO and repositories to Kotlin `Flow`
- use `StateFlow` in view models
- remove old ViewModel factories and switch to Koin DI
- update Compose screens to collect `Flow` state
- add `FootballApp` and DI module
- drop obsolete dependencies

## Testing
- `./gradlew test` *(fails: No route to host)*