### PR TITLE
Update endpoints to working football APIs

### DIFF
--- a/app/src/main/java/com/example/football/Splash.kt
+++ b/app/src/main/java/com/example/football/Splash.kt
@@ -10,7 +10,6 @@ class Splash : AppCompatActivity() {
         //setContentView(R.layout.activity_splash)
         super.onCreate(savedInstanceState)
 
-
         //
         val intent = Intent(this, MainActivity::class.java)
         startActivity(intent)

--- a/app/src/main/java/com/example/football/data/network/DataTransferObject.kt
+++ b/app/src/main/java/com/example/football/data/network/DataTransferObject.kt
@@ -3,43 +3,60 @@ package com.example.football.data.network
 import com.example.football.domain.Scores
 import com.example.football.domain.TeamOne
 import com.example.football.domain.TeamTwo
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 //table
 @JsonClass(generateAdapter = true)
-data class TableContainer(val table: List<NetworkTable>)
+data class TableContainer(val data: TableData)
 
 @JsonClass(generateAdapter = true)
-data class NetworkTable(
-    val name: String,
-    val total: Int,
-    val played: Int,
-    val win: Int,
-    val draw: Int,
-    val loss: Int,
+data class TableData(val standings: List<NetworkStanding>)
+
+@JsonClass(generateAdapter = true)
+data class NetworkStanding(
+    val team: TeamInfo,
+    val stats: List<Stat>
 )
+
+@JsonClass(generateAdapter = true)
+data class TeamInfo(val name: String)
+
+@JsonClass(generateAdapter = true)
+data class Stat(val name: String, val value: Int)
 
 
 //news
 @JsonClass(generateAdapter = true)
-data class NewsContainer(val articles: List<NetworkNews>)
+data class NewsContainer(@Json(name = "response") val articles: List<NetworkNews>)
 
 @JsonClass(generateAdapter = true)
 data class NetworkNews(
     val title: String,
-    val description: String,
-    val urlToImage: String?,
+    val competition: Competition?,
+    @Json(name = "thumbnail") val urlToImage: String?,
 )
+
+@JsonClass(generateAdapter = true)
+data class Competition(val name: String)
 
 
 //livescore
 @JsonClass(generateAdapter = true)
-data class LiveScoreContainer(val data: List<NetworkLive>)
+data class LiveScoreContainer(val events: List<NetworkLive>)
 
+@JsonClass(generateAdapter = true)
 data class NetworkLive(
-    val status: String,
-    val team_2: TeamTwo,
-    val team_1: TeamOne,
-    val score: Scores,
+    val status: Status,
+    @Json(name = "awayTeam") val team_2: TeamTwo?,
+    @Json(name = "homeTeam") val team_1: TeamOne?,
+    @Json(name = "awayScore") val awayScore: CurrentScore?,
+    @Json(name = "homeScore") val homeScore: CurrentScore?,
 )
+
+@JsonClass(generateAdapter = true)
+data class Status(val description: String)
+
+@JsonClass(generateAdapter = true)
+data class CurrentScore(val current: Int)
 

--- a/app/src/main/java/com/example/football/data/network/databaseMapper.kt
+++ b/app/src/main/java/com/example/football/data/network/databaseMapper.kt
@@ -4,17 +4,20 @@ package com.example.football.data.network
 import com.example.football.data.roomDatabase.LeagueTableDatabase
 import com.example.football.data.roomDatabase.NewsDatabase
 import com.example.football.domain.NetworkLiveScore
+import com.example.football.domain.Scores
+import com.example.football.domain.FullTime
 
 //table container
 fun TableContainer.asLeagueDataBaseModel(): Array<LeagueTableDatabase> {
-    return table.map {
+    return data.standings.map { standing ->
+        val stats = standing.stats.associateBy { it.name }
         LeagueTableDatabase(
-            name = it.name,
-            total = it.total,
-            played = it.played,
-            win = it.win,
-            draw = it.draw,
-            loss = it.loss
+            name = standing.team.name,
+            total = stats["points"]?.value ?: 0,
+            played = stats["gamesPlayed"]?.value ?: 0,
+            win = stats["wins"]?.value ?: 0,
+            draw = stats["draws"]?.value ?: 0,
+            loss = stats["losses"]?.value ?: 0
         )
     }.toTypedArray()
 
@@ -26,7 +29,7 @@ fun NewsContainer.asNewsDataBaseModel(): Array<NewsDatabase> {
     return articles.map {
         NewsDatabase(
             title = it.title,
-            description = it.description,
+            description = it.competition?.name ?: "",
             urlToImage = it.urlToImage
         )
     }.toTypedArray()
@@ -34,12 +37,17 @@ fun NewsContainer.asNewsDataBaseModel(): Array<NewsDatabase> {
 
 //liveScore container
 fun LiveScoreContainer.asLiveScoreDomainModel(): List<NetworkLiveScore> {
-    return data.map {
+    return events.map {
         NetworkLiveScore(
-            status = it.status,
+            status = it.status.description,
             team_2 = it.team_2,
             team_1 = it.team_1,
-            score = it.score
+            score = Scores(
+                full_time = FullTime(
+                    team_1 = it.homeScore?.current?.toString() ?: "0",
+                    team_2 = it.awayScore?.current?.toString() ?: "0"
+                )
+            )
         )
     }
 }

--- a/app/src/main/java/com/example/football/data/network/networkRequest.kt
+++ b/app/src/main/java/com/example/football/data/network/networkRequest.kt
@@ -22,7 +22,7 @@ private val moshi = Moshi.Builder()
 object TableApiCall {
     // Configure retrofit to parse JSON and use coroutines
     private val retrofit = Retrofit.Builder()
-        .baseUrl("https://www.thesportsdb.com/api/v1/json/1/")
+        .baseUrl("https://api-football-standings.azharimm.dev/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .addCallAdapterFactory(CoroutineCallAdapterFactory())
         .build()
@@ -36,7 +36,7 @@ object TableApiCall {
 object NewsApiCall {
     // Configure retrofit to parse JSON and use coroutines
     private val retrofit = Retrofit.Builder()
-        .baseUrl("http://newsapi.org/v2/")
+        .baseUrl("https://www.scorebat.com/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .addCallAdapterFactory(CoroutineCallAdapterFactory())
         .build()
@@ -49,7 +49,7 @@ object NewsApiCall {
 object LiveScoreApiCall {
     // Configure retrofit to parse JSON and use coroutines
     private val retrofit = Retrofit.Builder()
-        .baseUrl("https://livescore-football.p.rapidapi.com/soccer/")
+        .baseUrl("https://api.sofascore.com/api/v1/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .addCallAdapterFactory(CoroutineCallAdapterFactory())
         .build()

--- a/app/src/main/java/com/example/football/data/network/services.kt
+++ b/app/src/main/java/com/example/football/data/network/services.kt
@@ -9,7 +9,7 @@ import retrofit2.http.Headers
  * A retrofit service to fetch league table.
  */
 interface GetTableService {
-    @GET("lookuptable.php?l=4328&s=2020-2021")
+    @GET("leagues/eng.1/standings?season=2023&sort=asc")
     fun getLeagueTable(): Deferred<TableContainer>
 }
 
@@ -17,11 +17,7 @@ interface GetTableService {
  * A retrofit service to fetch live score.
  */
 interface GetLiveScoreService {
-    @Headers(
-        "x-rapidapi-key: c2e7e90134mshfc788d6b60b3aeep1de18ejsnd665ab39b49a",
-        "x-rapidapi-host: livescore-football.p.rapidapi.com"
-    )
-    @GET("matches-by-league?country_code=england&league_code=premier-league&timezone_utc=0%3A00&round=17")
+    @GET("sport/football/events/live")
     fun getliveScore(): Deferred<LiveScoreContainer>
 }
 
@@ -29,6 +25,6 @@ interface GetLiveScoreService {
  * A retrofit service to fetch News.
  */
 interface GetNewsService {
-    @GET("top-headlines?sports&apiKey=fcdbed254adc419592031f3fb4d86d72&country=gb")
+    @GET("video-api/v3/")
     fun getNews(): Deferred<NewsContainer>
 }


### PR DESCRIPTION
## Summary
- switch retrofit endpoints to new open football APIs
- update network DTOs to match new APIs
- map updated DTOs in database mapper

## Testing
- `./gradlew test` *(fails: No route to host when downloading Gradle)*